### PR TITLE
Unngå unødvendig deny fra ABAC

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/info/web/app/exceptions/GeneralRestExceptionMapper.java
+++ b/web/src/main/java/no/nav/foreldrepenger/info/web/app/exceptions/GeneralRestExceptionMapper.java
@@ -37,6 +37,8 @@ public class GeneralRestExceptionMapper implements ExceptionMapper<ApplicationEx
             return handleValideringsfeil((ValideringsfeilException) cause);
         } else if (cause instanceof TomtResultatException) {
             return handleTomtResultatFeil((TomtResultatException) cause);
+        } else if (cause instanceof IngenUttaksplanFunnetException) {
+            return tomtResultat();
         }
 
         loggTilApplikasjonslogg(cause);
@@ -50,6 +52,7 @@ public class GeneralRestExceptionMapper implements ExceptionMapper<ApplicationEx
     }
 
     private Response handleTomtResultatFeil(TomtResultatException tomtResultatException) {
+
         return Response
                 .status(Response.Status.NOT_FOUND)
                 .entity(new FeilDto(FeilType.TOMT_RESULTAT_FEIL, tomtResultatException.getMessage()))
@@ -75,6 +78,10 @@ public class GeneralRestExceptionMapper implements ExceptionMapper<ApplicationEx
         } else {
             return serverError(callId, feil);
         }
+    }
+
+    private Response tomtResultat() {
+        return Response.ok().build();
     }
 
     private Response serverError(String callId, Feil feil) {

--- a/web/src/main/java/no/nav/foreldrepenger/info/web/app/exceptions/IngenUttaksplanFunnetException.java
+++ b/web/src/main/java/no/nav/foreldrepenger/info/web/app/exceptions/IngenUttaksplanFunnetException.java
@@ -1,0 +1,7 @@
+package no.nav.foreldrepenger.info.web.app.exceptions;
+
+public class IngenUttaksplanFunnetException extends RuntimeException {
+    public IngenUttaksplanFunnetException(String msg) {
+        super(msg);
+    }
+}


### PR DESCRIPTION
Ønsker å stoppe kall til abac når det ikke finnes aktuell sak. Dette for å unngå støyende deny på noe vi selv vet ikke er relevant. Så er spørsmålet hvordan det bør gjøres, og forslaget etter å ha sett på dette med Jan-Olav var å kaste en exception i PdpRequestBuilder og mappe exception til tom resultatliste.

Har du noen innspill? Mangler bla:
- deklarere at lagPdpRequest-metoden kaster exception.. det går kanskje ikke når vi bruker felleskoden?
- test..