### PR TITLE
Legger på AD grupper som kan kreve OBO tokens fra fpinfo

### DIFF
--- a/.deploy/dev-fss-teamforeldrepenger.json
+++ b/.deploy/dev-fss-teamforeldrepenger.json
@@ -11,9 +11,11 @@
     "https://fpinfo.dev-fss-pub.nais.io"
   ],
   "env": {
-    "APPDYNAMICS_AGENT_ACCOUNT_NAME": "NON-PROD",
     "APPD_ENABLED": "false"
   },
+  "groups": [
+    "f1b82579-c5b5-4617-9673-8ace5ff67f63"
+  ],
   "AZURE_IAC_RULES": [
     {
       "app": "fp-swagger",

--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -55,10 +55,10 @@ spec:
         mountPath: /var/run/secrets/nais.io/appdynamics
 
   env:
-{{#each env}}
+  {{#each env}}
     - name: {{@key}}
       value: "{{this}}"
-{{/each}}
+  {{/each}}
   azure:
     application:
       enabled: true
@@ -66,20 +66,24 @@ spec:
         extra:
           - "NAVident"
           - "azp_name"
+        groups:
+          {{#each groups as |group|}}
+          - id: "{{group}}"
+          {{/each}}
   {{#if AZURE_IAC_RULES}}
   accessPolicy:
-     inbound:
-        rules:
-        {{#each AZURE_IAC_RULES}}
-           - application: {{app}}
-             namespace: {{namespace}}
-             cluster: {{cluster}}
-             {{#if scopes}}
-             permissions:
-                scopes:
-                {{#each scopes}}
-                   - "{{this}}"
-                {{/each}}
-             {{/if}}
-        {{/each}}
+    inbound:
+      rules:
+      {{#each AZURE_IAC_RULES}}
+      - application: {{app}}
+        namespace: {{namespace}}
+        cluster: {{cluster}}
+        {{#if scopes}}
+        permissions:
+          scopes:
+          {{#each scopes}}
+            - "{{this}}"
+          {{/each}}
+        {{/if}}
+      {{/each}}
   {{/if}}

--- a/.deploy/prod-fss-teamforeldrepenger.json
+++ b/.deploy/prod-fss-teamforeldrepenger.json
@@ -11,9 +11,11 @@
     "https://fpinfo.prod-fss-pub.nais.io"
   ],
   "env": {
-    "APPDYNAMICS_AGENT_ACCOUNT_NAME": "PROD",
     "APPD_ENABLED": "true"
   },
+  "groups": [
+    "0d226374-4748-4367-a38a-062dcad70034"
+  ],
   "AZURE_IAC_RULES": [
     {
       "app": "fp-swagger",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,10 +19,3 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 20
-    ignore:
-      - dependency-name: "no.nav.vedtak.prosesstask:*"
-        versions: ["x", "x.x"]
-      - dependency-name: "no.nav.foreldrepenger.felles:*"
-        versions: ["x", "x.x"]
-      - dependency-name: "no.nav.foreldrepenger.kontrakter:*"
-        versions: ["x", "x.x"]

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -11,37 +11,8 @@ on:
 
 jobs:
   snyk:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - uses: snyk/actions/setup@master
-
-      - name: Setup maven
-        uses: whelk-io/maven-settings-xml-action@v21
-        with:
-          repositories: '[{ "id": "github", "name": "github", "url": "https://maven.pkg.github.com/${{ github.repository }}", "releases": { "enabled": "true" }, "snapshots": { "enabled": "false" } }]'
-          servers: '[{ "id": "github", "username": "${{ github.actor }}", "password": "${{ secrets.READER_TOKEN }}" }]'
-          output_file: settings.xml
-
-      - name: Build
-        run: |
-          echo "Building snyk-snapshot"
-          mvn -B -s settings.xml versions:set -DnewVersion=snyk-snapshot
-          mvn install -q -B -s settings.xml -DskipTests
-
-      - name: Run Snyk monitor
-        run: >
-          snyk monitor
-          --org=teamforeldrepenger
-          --all-projects
-          --configuration-attributes=usage:java-runtime
-          --remote-repo-url=https://github.com/${{ github.repository }}.git
-          -- -s settings.xml
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+    name: Snyk
+    uses: navikt/fp-gha-workflows/.github/workflows/snyk.yml@main
+    with:
+      build-version: snyk-snapshot
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -2,3 +2,10 @@
 Rest-grensesnitt for å slå opp behandlinger i fpsak. Går dessverre mot views i fpsak.   
 
 Brukes av selvbetjening. 
+
+### Sikkerhet
+Det er mulig å kalle tjenesten med bruk av følgende tokens
+- Azure CC
+- Azure OBO med følgende rettigheter:
+    - fpsak-drift
+- TokenX


### PR DESCRIPTION
Enforcet endring av NAIS https://nav-it.slack.com/archives/C01DE3M9YBV/p1674475818557619

Per i dag er det brukere fra følgende azure grupper som får lov å kommunisere med fpinfo med en OBO:
- fpsak-drift (swagger)